### PR TITLE
Fix asset loading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/3_d_claw_crane_game.js
+++ b/3_d_claw_crane_game.js
@@ -3,9 +3,9 @@
 // This is a foundation to build on. You can customize all models and assets.
 
 import * as THREE from './node_modules/three/build/three.module.js';
-import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls';
-import * as CANNON from 'cannon-es';
-import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader';
+import { OrbitControls } from './node_modules/three/examples/jsm/controls/OrbitControls.js';
+import * as CANNON from './node_modules/cannon-es/dist/cannon-es.js';
+import { GLTFLoader } from './node_modules/three/examples/jsm/loaders/GLTFLoader.js';
 
 // Basic scene setup
 const scene = new THREE.Scene();

--- a/3_d_claw_crane_game.js
+++ b/3_d_claw_crane_game.js
@@ -2,7 +2,7 @@
 // You can deploy and run this as a browser-based game. We'll allow you to upload your own prize models.
 // This is a foundation to build on. You can customize all models and assets.
 
-import * as THREE from 'three';
+import * as THREE from './node_modules/three/build/three.module.js';
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls';
 import * as CANNON from 'cannon-es';
 import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader';

--- a/claw_crane_asset_loader.html
+++ b/claw_crane_asset_loader.html
@@ -29,10 +29,10 @@
     <button id="drop">🕹️ Drop</button>
   </div>
   <script type="module">
-    import * as THREE from 'https://unpkg.com/three@0.160.0/build/three.module.js';
-    import { OrbitControls } from 'https://unpkg.com/three@0.160.0/examples/jsm/controls/OrbitControls.js';
-    import * as CANNON from 'https://cdn.skypack.dev/cannon-es';
-    import { GLTFLoader } from 'https://unpkg.com/three@0.160.0/examples/jsm/loaders/GLTFLoader.js';
+    import * as THREE from './node_modules/three/build/three.module.js';
+    import { OrbitControls } from './node_modules/three/examples/jsm/controls/OrbitControls.js';
+    import * as CANNON from './node_modules/cannon-es/dist/cannon-es.js';
+    import { GLTFLoader } from './node_modules/three/examples/jsm/loaders/GLTFLoader.js';
 
     // Load sounds
     const dropSound = new Audio("assets/sounds/drop.mp3");
@@ -109,13 +109,13 @@
     const loader = new GLTFLoader();
     const prizes = [];
     const prizeUrls = [
-      '/mnt/data/kylecasual.glb',
-      '/mnt/data/kyleflex.glb',
-      '/mnt/data/kylelistens.glb',
-      '/mnt/data/margoplays.glb',
-      '/mnt/data/shellydreadeddiva.glb',
-      '/mnt/data/shellyjemima.glb',
-      '/mnt/data/vickiejams.glb'
+      'assets/models/kylecasual.glb',
+      'assets/models/kyleflex.glb',
+      'assets/models/kylelistens.glb',
+      'assets/models/margoplays.glb',
+      'assets/models/shellydreadeddiva.glb',
+      'assets/models/shellyjemima.glb',
+      'assets/models/vickiejams.glb'
     ];
 
     prizeUrls.forEach((url, index) => {

--- a/claw_crane_starter.html
+++ b/claw_crane_starter.html
@@ -11,10 +11,10 @@
 </head>
 <body>
   <script type="module">
-    import * as THREE from 'https://unpkg.com/three@0.160.0/build/three.module.js';
-    import { OrbitControls } from 'https://unpkg.com/three@0.160.0/examples/jsm/controls/OrbitControls.js';
-    import * as CANNON from 'https://cdn.skypack.dev/cannon-es';
-    import { GLTFLoader } from 'https://unpkg.com/three@0.160.0/examples/jsm/loaders/GLTFLoader.js';
+    import * as THREE from './node_modules/three/build/three.module.js';
+    import { OrbitControls } from './node_modules/three/examples/jsm/controls/OrbitControls.js';
+    import * as CANNON from './node_modules/cannon-es/dist/cannon-es.js';
+    import { GLTFLoader } from './node_modules/three/examples/jsm/loaders/GLTFLoader.js';
 
     const scene = new THREE.Scene();
     const camera = new THREE.PerspectiveCamera(75, window.innerWidth/window.innerHeight, 0.1, 1000);

--- a/index.html
+++ b/index.html
@@ -34,11 +34,10 @@
   <div id="catalog"><h3>Prize Catalog</h3></div>
   <canvas></canvas>
   <script type="module">
-    // Use explicit CDN paths to avoid bare specifier errors
-    import * as THREE from 'https://unpkg.com/three@0.160.0/build/three.module.js';
-    import { OrbitControls } from 'https://unpkg.com/three@0.160.0/examples/jsm/controls/OrbitControls.js';
-    import { GLTFLoader } from 'https://unpkg.com/three@0.160.0/examples/jsm/loaders/GLTFLoader.js';
-    import * as CANNON from 'https://cdn.skypack.dev/cannon-es';
+    import * as THREE from './node_modules/three/build/three.module.js';
+    import { OrbitControls } from './node_modules/three/examples/jsm/controls/OrbitControls.js';
+    import { GLTFLoader } from './node_modules/three/examples/jsm/loaders/GLTFLoader.js';
+    import * as CANNON from './node_modules/cannon-es/dist/cannon-es.js';
 
     // Audio
     const dropSound = new Audio('assets/sounds/drop.mp3');
@@ -140,7 +139,7 @@
     // Prizes
     const loader=new GLTFLoader(), prizes=[];
     ['kylecasual','kyleflex','kylelistens','margoplays','shellydreadeddiva','shellyjemima','vickiejams']
-      .forEach(name=>loader.load(`/mnt/data/${name}.glb`,g=>{const m=g.scene; m.scale.set(0.5,0.5,0.5); m.position.set((Math.random()-0.5)*5,0.6,(Math.random()-0.5)*5); scene.add(m); prizes.push(m);}));
+      .forEach(name=>loader.load(`assets/models/${name}.glb`,g=>{const m=g.scene; m.scale.set(0.5,0.5,0.5); m.position.set((Math.random()-0.5)*5,0.6,(Math.random()-0.5)*5); scene.add(m); prizes.push(m);}));
 
     let dropping=false, dropDir=-0.05, grabbed=null;
     function setFingers(open){fingers.forEach(f=>{const t=open?f.userData.open:0; f.rotation.z+=(t-f.rotation.z)*0.2;});}

--- a/package-lock.json
+++ b/package-lock.json
@@ -2,5 +2,24 @@
   "name": "claw-crane-arcade",
   "lockfileVersion": 3,
   "requires": true,
-  "packages": {}
+  "packages": {
+    "": {
+      "dependencies": {
+        "cannon-es": "^0.20.0",
+        "three": "^0.160.0"
+      }
+    },
+    "node_modules/cannon-es": {
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/cannon-es/-/cannon-es-0.20.0.tgz",
+      "integrity": "sha512-eZhWTZIkFOnMAJOgfXJa9+b3kVlvG+FX4mdkpePev/w/rP5V8NRquGyEozcjPfEoXUlb+p7d9SUcmDSn14prOA==",
+      "license": "MIT"
+    },
+    "node_modules/three": {
+      "version": "0.160.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.160.0.tgz",
+      "integrity": "sha512-DLU8lc0zNIPkM7rH5/e1Ks1Z8tWCGRq6g8mPowdDJpw1CFBJMU7UoJjC6PefXW7z//SSl0b2+GCw14LB+uDhng==",
+      "license": "MIT"
+    }
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "dependencies": {
         "cannon-es": "^0.20.0",
-        "three": "^0.160.0"
+        "three": "^0.160.1"
       }
     },
     "node_modules/cannon-es": {
@@ -16,9 +16,9 @@
       "license": "MIT"
     },
     "node_modules/three": {
-      "version": "0.160.0",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.160.0.tgz",
-      "integrity": "sha512-DLU8lc0zNIPkM7rH5/e1Ks1Z8tWCGRq6g8mPowdDJpw1CFBJMU7UoJjC6PefXW7z//SSl0b2+GCw14LB+uDhng==",
+      "version": "0.160.1",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.160.1.tgz",
+      "integrity": "sha512-Bgl2wPJypDOZ1stAxwfWAcJ0WQf7QzlptsxkjYiURPz+n5k4RBDLsq+6f9Y75TYxn6aHLcWz+JNmwTOXWrQTBQ==",
       "license": "MIT"
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,6 @@
+{
+  "dependencies": {
+    "cannon-es": "^0.20.0",
+    "three": "^0.160.0"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
     "cannon-es": "^0.20.0",
-    "three": "^0.160.0"
+    "three": "^0.160.1"
   }
 }

--- a/server.js
+++ b/server.js
@@ -1,0 +1,38 @@
+// Simple static file server for the claw crane arcade game
+// Usage: node server.js
+
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+
+const port = 5000;
+const mimeTypes = {
+  '.html': 'text/html',
+  '.js': 'application/javascript',
+  '.css': 'text/css',
+  '.json': 'application/json',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.gif': 'image/gif',
+  '.mp3': 'audio/mpeg',
+  '.glb': 'model/gltf-binary',
+};
+
+http.createServer((req, res) => {
+  let filePath = '.' + decodeURIComponent(req.url.split('?')[0]);
+  if (filePath === './') filePath = './index.html';
+  const ext = String(path.extname(filePath)).toLowerCase();
+  const contentType = mimeTypes[ext] || 'application/octet-stream';
+
+  fs.readFile(filePath, (err, content) => {
+    if (err) {
+      res.writeHead(404, { 'Content-Type': 'text/plain' });
+      res.end('404 Not Found');
+    } else {
+      res.writeHead(200, { 'Content-Type': contentType });
+      res.end(content, 'utf-8');
+    }
+  });
+}).listen(port, () => {
+  console.log(`Server running at http://localhost:${port}/`);
+});


### PR DESCRIPTION
## Summary
- load Three.js, OrbitControls, GLTFLoader and cannon-es from local `node_modules`
- use local paths for prize models
- add a minimal package.json with dependencies
- ignore `node_modules`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684d3073173883288388966b353365b5