### PR TITLE
Fix asset paths to use GitHub raw URLs

### DIFF
--- a/claw_crane_asset_loader.html
+++ b/claw_crane_asset_loader.html
@@ -107,16 +107,19 @@
     }
 
     const loader = new GLTFLoader();
+    loader.setCrossOrigin('anonymous');
     const prizes = [];
+    const prizeBase =
+      'https://raw.githubusercontent.com/kmberry1989/claw-crane-arcade/main/assets/models/';
     const prizeUrls = [
-      '/mnt/data/kylecasual.glb',
-      '/mnt/data/kyleflex.glb',
-      '/mnt/data/kylelistens.glb',
-      '/mnt/data/margoplays.glb',
-      '/mnt/data/shellydreadeddiva.glb',
-      '/mnt/data/shellyjemima.glb',
-      '/mnt/data/vickiejams.glb'
-    ];
+      'kylecasual.glb',
+      'kyleflex.glb',
+      'kylelistens.glb',
+      'margoplays.glb',
+      'shellydreadeddiva.glb',
+      'shellyjemima.glb',
+      'vickiejams.glb'
+    ].map(name => prizeBase + name);
 
     prizeUrls.forEach((url, index) => {
       loader.load(url, (gltf) => {

--- a/index.html
+++ b/index.html
@@ -138,9 +138,13 @@
     }
 
     // Prizes
-    const loader=new GLTFLoader(), prizes=[];
+    const loader=new GLTFLoader();
+    loader.setCrossOrigin('anonymous');
+    const prizes=[];
+    const prizeBase=
+      'https://raw.githubusercontent.com/kmberry1989/claw-crane-arcade/main/assets/models/';
     ['kylecasual','kyleflex','kylelistens','margoplays','shellydreadeddiva','shellyjemima','vickiejams']
-      .forEach(name=>loader.load(`/mnt/data/${name}.glb`,g=>{const m=g.scene; m.scale.set(0.5,0.5,0.5); m.position.set((Math.random()-0.5)*5,0.6,(Math.random()-0.5)*5); scene.add(m); prizes.push(m);}));
+      .forEach(name=>loader.load(prizeBase+`${name}.glb`,g=>{const m=g.scene; m.scale.set(0.5,0.5,0.5); m.position.set((Math.random()-0.5)*5,0.6,(Math.random()-0.5)*5); scene.add(m); prizes.push(m);}));
 
     let dropping=false, dropDir=-0.05, grabbed=null;
     function setFingers(open){fingers.forEach(f=>{const t=open?f.userData.open:0; f.rotation.z+=(t-f.rotation.z)*0.2;});}


### PR DESCRIPTION
## Summary
- load prize models from raw GitHub repo URLs so assets aren't relative to local server
- allow cross-origin loading for GLTF models

## Testing
- `python3 -m http.server 8000 > /tmp/server.log 2>&1 &`
- `curl -I http://localhost:8000/index.html`
- `curl -I http://localhost:8000/assets/models/kylecasual.glb`
- `curl -I https://raw.githubusercontent.com/kmberry1989/claw-crane-arcade/main/assets/models/kylecasual.glb`


------
https://chatgpt.com/codex/tasks/task_e_684d5be18e508328905f35e3c976438c